### PR TITLE
Adjust report filname format in parser

### DIFF
--- a/report-preprocessing/README.md
+++ b/report-preprocessing/README.md
@@ -37,7 +37,7 @@ node ./build-index.js -s <source pdf>  -i 統編 -y 資料年度
 
 ```
 # 假設 PDF 少於 9,999 頁
-./minify-pdf.sh ./path/to/csr/report.pdf ./path/to/output/dir
+./split-n-minify.sh ./path/to/csr/report.pdf ./path/to/output/dir
 ```
 
 並將 PDF 上傳到合適的線上空間

--- a/report-preprocessing/process-reports.js
+++ b/report-preprocessing/process-reports.js
@@ -38,13 +38,10 @@ async function main (argPayload) {
   const ignoreList = buildIgnoreList(argPayload.ignore || [])
 
   for (const reportName of argPayload.src) {
-    // reportName = <company name>-<year>.pdf
-    const [name, year] = path.parse(reportName).name.split('-').map(s => s.trim())
-    const companyId = companyMap.name[name] || companyMap.abbr[name]
-
-    // // reportName = <dummy0>_<dummy1>_<tw year>_<company id>.pdf
-    // const [dummy0, dummy1, twYear, companyId] = path.parse(reportName).name.split('_').map(s => s.trim())
-    // const year = Number(twYear) + 1911
+    // reportName = <stockId>_<twYear>_<companyId>.pdf (<股票代號>_<資料年份(民國)>_<統一編號>.pdf)
+    // example: 1102_112_03244509.pdf
+    const [stockId, twYear, companyId] = path.parse(reportName).name.split('_').map(s => s.trim())
+    const year = Number(twYear) + 1911
 
     if (!companyId) {
       console.error(`***** Cannot find company ID for ${reportName} *****`)


### PR DESCRIPTION
Small fixes:

1. Adjust `process-reports.js` to read pdf of filename `<股票代號>_<資料年份(民國)>_<統一編號>.pdf`
2. Update script name `split-n-minify.sh` in README.md

<img width="500" alt="image" src="https://github.com/user-attachments/assets/2a579b4f-3664-4e34-9acc-1fa1af192360">

