### PR TITLE
bug: sync page index(ui)

### DIFF
--- a/toolkit-ui/components/profession/PdfViewer.vue
+++ b/toolkit-ui/components/profession/PdfViewer.vue
@@ -506,11 +506,10 @@ function handleZoomLevelMouseScroll (event: WheelEvent) {
 // page view
 
 const handlePageVisible = _.debounce((pageIndex: number) => {
-  if (pageIndex === nextPageIndex.value) {
-    return
-  }
-  curPageIndex.value = nextPageIndex.value
   nextPageIndex.value = pageIndex
+  if (nextPageIndex.value !== curPageIndex.value) {
+    curPageIndex.value = nextPageIndex.value
+  }
   emit('view-page', curPageIndex.value)
 }, TIME_TO_GLANCE_PAGE)
 


### PR DESCRIPTION
修正問題：
1. 於判讀結果無法同步關鍵字所在的頁碼
2.  跳轉頁面時沒有即時更新頁碼顯示的數字